### PR TITLE
Avoid returning nulls when the result is not found

### DIFF
--- a/src/main/java/kr/co/shineware/ds/aho_corasick/AhoCorasickDictionary.java
+++ b/src/main/java/kr/co/shineware/ds/aho_corasick/AhoCorasickDictionary.java
@@ -141,7 +141,7 @@ public class AhoCorasickDictionary<V> {
 			if (children == null) {
 				final AhoCorasickNode<V> currentNode = context.getCurrentFailNode();
 				if (currentNode == null) {
-					return null;
+					return new HashMap<>();
 				} else {
 					context.setCurrentNode(currentNode);
 				}
@@ -171,9 +171,7 @@ public class AhoCorasickDictionary<V> {
 			}
 			break;
 		}
-		if(resultMap.size() == 0){
-			return null;
-		}
+
 		return resultMap;
 	}	
 
@@ -208,9 +206,6 @@ public class AhoCorasickDictionary<V> {
 
 		for (int i = 0; i < keys.length; i++) {
 			resultMap.putAll(get(context, keys[i]));
-		}
-		if(resultMap.size() == 0){
-			return null;
 		}
 		return resultMap;
 	}

--- a/src/test/java/kr/co/shineware/ds/aho_corasick/AhoCorasickDictionaryConcurrencyTest.java
+++ b/src/test/java/kr/co/shineware/ds/aho_corasick/AhoCorasickDictionaryConcurrencyTest.java
@@ -1,0 +1,89 @@
+package kr.co.shineware.ds.aho_corasick;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AhoCorasickDictionaryConcurrencyTest {
+
+	private static ExecutorService service;
+	private static final int THREAD_NUM = 4;
+	private static final int DATA_NUM = 100000;
+
+	private static String[] KEYS;
+	private static Integer[] VALS;
+
+	private static final AhoCorasickDictionary<Integer> dic = new AhoCorasickDictionary<>();
+
+	@BeforeClass
+	public static void setup() {
+		KEYS = new String[DATA_NUM];
+		VALS = new Integer[DATA_NUM];
+
+		for (int i = 0; i < KEYS.length; i++) {
+			KEYS[i] = Integer.toString(i);
+			VALS[i] = i;
+		}
+
+		for (int i = 0; i < KEYS.length; i++) {
+			dic.put(KEYS[i], VALS[i]);
+		}
+		dic.buildFailLink();
+
+		service = Executors.newFixedThreadPool(THREAD_NUM);
+	}
+
+	@AfterClass
+	public static void teardown() {
+		if (service != null) {
+			service.shutdown();
+		}
+	}
+
+	@Test
+	public void testSequentialGet() {
+		for (int i = 0; i < KEYS.length; i++) {
+			final Map<String, Integer> result = dic.get(KEYS[i]);
+			final Set<Integer> expectedResult = expectedResultSet(KEYS[i]);
+
+			assertEquals(expectedResult, new HashSet<>(result.values()));
+		}
+	}
+
+	@Test
+	public void testConcurrentGet() throws ExecutionException, InterruptedException {
+		final List<Future> futures = new ArrayList<>();
+		for (int i = 0; i < KEYS.length; i++) {
+			final int index = i;
+			futures.add(service.submit(new Callable<Set<Integer>>() {
+				@Override
+				public Set<Integer> call() throws Exception {
+					return new HashSet<>(dic.get(KEYS[index]).values());
+				}
+			}));
+		}
+
+		for (int i = 0; i < futures.size(); i++) {
+			final Set<Integer> expectedResult = expectedResultSet(KEYS[i]);
+			assertEquals(expectedResult, futures.get(i).get());
+		}
+	}
+
+	private static Set<Integer> expectedResultSet(final String str) {
+		final Set<Integer> resultSet = new HashSet<>();
+
+		for (int subStrLen = 1; subStrLen < str.length() + 1; subStrLen++) {
+			for (int subStrBeginIdx = 0; subStrBeginIdx + subStrLen <= str.length(); subStrBeginIdx++) {
+				final String subStr = str.substring(subStrBeginIdx, subStrBeginIdx + subStrLen);
+				resultSet.add(Integer.parseInt(subStr));
+			}
+		}
+
+		return resultSet;
+	}
+}

--- a/src/test/java/kr/co/shineware/ds/aho_corasick/AhoCorasickDictionaryTest.java
+++ b/src/test/java/kr/co/shineware/ds/aho_corasick/AhoCorasickDictionaryTest.java
@@ -1,20 +1,16 @@
 package kr.co.shineware.ds.aho_corasick;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.*;
-import java.util.concurrent.*;
-
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
 public class AhoCorasickDictionaryTest {
 
-	private static ExecutorService service;
-	private static final int THREAD_NUM = 4;
-	private static final int DATA_NUM = 100000;
-
+	private static final int DATA_NUM = 100;
 	private static String[] KEYS;
 	private static Integer[] VALS;
 
@@ -34,15 +30,6 @@ public class AhoCorasickDictionaryTest {
 			dic.put(KEYS[i], VALS[i]);
 		}
 		dic.buildFailLink();
-
-		service = Executors.newFixedThreadPool(THREAD_NUM);
-	}
-
-	@AfterClass
-	public static void teardown() {
-		if (service != null) {
-			service.shutdown();
-		}
 	}
 
 	@Test
@@ -71,44 +58,7 @@ public class AhoCorasickDictionaryTest {
 	}
 
 	@Test
-	public void testSequentialGet() {
-		for (int i = 0; i < KEYS.length; i++) {
-			final Map<String, Integer> result = dic.get(KEYS[i]);
-			final Set<Integer> expectedResult = expectedResultSet(KEYS[i]);
-
-			assertEquals(expectedResult, new HashSet<>(result.values()));
-		}
-	}
-
-	@Test
-	public void testConcurrentGet() throws ExecutionException, InterruptedException {
-		final List<Future> futures = new ArrayList<>();
-		for (int i = 0; i < KEYS.length; i++) {
-			final int index = i;
-			futures.add(service.submit(new Callable<Set<Integer>>() {
-				@Override
-				public Set<Integer> call() throws Exception {
-					return new HashSet<>(dic.get(KEYS[index]).values());
-				}
-			}));
-		}
-
-		for (int i = 0; i < futures.size(); i++) {
-			final Set<Integer> expectedResult = expectedResultSet(KEYS[i]);
-			assertEquals(expectedResult, futures.get(i).get());
-		}
-	}
-
-	private static Set<Integer> expectedResultSet(final String str) {
-		final Set<Integer> resultSet = new HashSet<>();
-
-		for (int subStrLen = 1; subStrLen < str.length() + 1; subStrLen++) {
-			for (int subStrBeginIdx = 0; subStrBeginIdx + subStrLen <= str.length(); subStrBeginIdx++) {
-				final String subStr = str.substring(subStrBeginIdx, subStrBeginIdx + subStrLen);
-				resultSet.add(Integer.parseInt(subStr));
-			}
-		}
-
-		return resultSet;
+	public void testNotFound() {
+		assertEquals(new HashMap<>(), dic.get(dic.newFindContext(), "가"));
 	}
 }


### PR DESCRIPTION
get() 함수에서 결과를 찾지 못하였을 때 null을 리턴하는 것을 빈 map을 리턴하도록 수정하였습니다. 그 이유는 다음과 같습니다.

* 내부 에러가 발생했을 때 null을, 결과가 없을 때 빈 map을 리턴함으로써 에러가 발생한 케이스와 정상적으로 동작하였지만 결과가 없는 경우를 구분할 수 있습니다.
* null은 실수로 NullPointerException을 일으키기 쉽기 때문에 사용하지 않는 편이 좋다고 생각합니다.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shineware/aho-corasick/4)
<!-- Reviewable:end -->
